### PR TITLE
Makefile, Dockerfile, and Factorio updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [v1.1.0](https://github.com/fboulnois/factorio-docker/compare/v1.0.9...v1.1.0) - 2024-01-16
+
+### Added
+
+* Update factorio to 1.1.101
+* Improve docker sudo detection in Makefile
+
+### Changed
+
+* Use docker compose instead of swarm
+* Use make notdir function built-in
+
 ## [v1.0.9](https://github.com/fboulnois/factorio-docker/compare/v1.0.8...v1.0.9) - 2023-12-19
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM debian:12-slim AS env-build
 
 RUN apt-get update && apt-get install -y curl xz-utils
 
-ARG FACTORIO_VERSION=1.1.100
-ARG FACTORIO_SHA256="9850dd146f93ee4da8ba06316591888860a4058c8548409cdfb5dd693abcd834"
+ARG FACTORIO_VERSION=1.1.101
+ARG FACTORIO_SHA256="0688a6f615a87bf73d3f46b53dc423ee37cad3fc4412723f3d7450aed1638392"
 
 RUN curl -A "Mozilla/5.0 (Windows NT 10.0; rv:100.0) Gecko/20100101 Firefox/100.0" \
   -LO https://www.factorio.com/get-download/${FACTORIO_VERSION}/headless/linux64 \

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,6 @@
 DOCKER := $(if $(shell docker ps >/dev/null 2>&1 && echo ok), docker, sudo docker)
 
-EMPTY :=
-SPACE := $(EMPTY) $(EMPTY)
-DIRNAME := $(lastword $(subst /,$(SPACE),$(subst $(SPACE),_,$(CURDIR))))
+DIRNAME := $(notdir $(CURDIR))
 
 .PHONY: build bootstrap clean purge deploy rm
 

--- a/Makefile
+++ b/Makefile
@@ -7,17 +7,14 @@ DIRNAME := $(notdir $(CURDIR))
 build:
 	$(DOCKER) build . --tag $(DIRNAME)
 
-bootstrap:
-	$(DOCKER) swarm init || true
-
 clean:
 	$(DOCKER) system prune -f
 
 purge: clean
 	$(DOCKER) volume prune -f
 
-deploy:
-	$(DOCKER) stack deploy -c docker-compose.yml $(DIRNAME)
+up:
+	$(DOCKER) compose up
 
-rm:
-	$(DOCKER) stack rm $(DIRNAME)
+down:
+	$(DOCKER) compose down

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-DOCKER := $(if $(shell docker ps >/dev/null 2>&1 && echo ok), docker, sudo docker)
-
+USE_SUDO := $(shell which docker >/dev/null && docker ps 2>&1 | grep -q "permission denied" && echo sudo)
+DOCKER := $(if $(USE_SUDO), sudo docker, docker)
 DIRNAME := $(notdir $(CURDIR))
 
 .PHONY: build bootstrap clean purge deploy rm


### PR DESCRIPTION
Makefile updates:

- Use make `notdir` function

Docker updates:

- Use docker compose instead of swarm
- Improve docker sudo detection

Factorio updates:

- Update Factorio to 1.1.1.01